### PR TITLE
render should return null only if the blockingRender flag was passed

### DIFF
--- a/js/react-tweek/index.js
+++ b/js/react-tweek/index.js
@@ -5,7 +5,7 @@ const prepareRequests = [];
 let globalTweekRepository = null;
 let onError = null;
 let shouldPrepare = true;
-export const withTweekKeys = (path, {mergeProps = true, propName} = {}) => {
+export const withTweekKeys = (path, {mergeProps = true, blockingRender = false, propName} = {}) => {
     
     if (shouldPrepare) {
         if (globalTweekRepository) {
@@ -52,7 +52,7 @@ export const withTweekKeys = (path, {mergeProps = true, propName} = {}) => {
         }
 
         render() {
-            return this.state.tweekProps ? <EnhancedComponent {...this.props} {...this.state.tweekProps} /> : null;
+            return !this.state.tweekProps && blockingRender ? null : <EnhancedComponent {...this.props} {...this.state.tweekProps} />;
         }
     }
 };


### PR DESCRIPTION
In the current behavior the render is blocked until the config is fetched (null is returned on the render).
This is causing render "jumps" on some updates.
For example - on our app we have a react-native ListView with withTweekKeys enhancement on every item, removing one item causes a "jump" (short white-out) to the entire list..