### PR TITLE
Allow Validator

### DIFF
--- a/js/react-tweek/index.js
+++ b/js/react-tweek/index.js
@@ -5,7 +5,7 @@ const prepareRequests = [];
 let globalTweekRepository = null;
 let onError = null;
 let shouldPrepare = true;
-export const withTweekKeys = (path, {mergeProps = true, propName} = {}) => {
+export const withTweekKeys = (path, {mergeProps = true, propName = null, validate = () => true, defaultValue} = {}) => {
     
     if (shouldPrepare) {
         if (globalTweekRepository) {
@@ -42,7 +42,10 @@ export const withTweekKeys = (path, {mergeProps = true, propName} = {}) => {
             else {
                 const configName = path.split('/').pop();
                 promise.then(result => {
-                    if (mergeProps) {
+                    if (!validate(result.value)) {
+                        this.setState({ tweekProps: { [propName || camelize(configName)]: defaultValue } });
+                    }
+                    else if (mergeProps) {
                         this.setState({ tweekProps: { [propName || camelize(configName)]: result.value } });
                     } else {
                         this.setState({ tweekProps: { [propName || "tweek"]: { [camelize(configName)]: result.value } } });

--- a/js/react-tweek/index.js
+++ b/js/react-tweek/index.js
@@ -5,7 +5,7 @@ const prepareRequests = [];
 let globalTweekRepository = null;
 let onError = null;
 let shouldPrepare = true;
-export const withTweekKeys = (path, {mergeProps = true, propName = null, validator = {validateFunction = () => true, defaultValue = null}} = {}) => {
+export const withTweekKeys = (path, {mergeProps = true, propName = null, validator = {validateFunction = (value) => true, defaultValue = null}} = {}) => {
     
     if (shouldPrepare) {
         if (globalTweekRepository) {
@@ -42,8 +42,8 @@ export const withTweekKeys = (path, {mergeProps = true, propName = null, validat
             else {
                 const configName = path.split('/').pop();
                 promise.then(result => {
-                    if (!validate(result.value)) {
-                        this.setState({ tweekProps: { [propName || camelize(configName)]: defaultValue } });
+                    if (validator && !validator.validateFunction(result.value)) {
+                        this.setState({ tweekProps: { [propName || camelize(configName)]: validator.defaultValue } });
                     }
                     else if (mergeProps) {
                         this.setState({ tweekProps: { [propName || camelize(configName)]: result.value } });

--- a/js/react-tweek/index.js
+++ b/js/react-tweek/index.js
@@ -5,7 +5,7 @@ const prepareRequests = [];
 let globalTweekRepository = null;
 let onError = null;
 let shouldPrepare = true;
-export const withTweekKeys = (path, {mergeProps = true, propName = null, validate = () => true, defaultValue} = {}) => {
+export const withTweekKeys = (path, {mergeProps = true, propName = null, validator = {validateFunction = () => true, defaultValue = null}} = {}) => {
     
     if (shouldPrepare) {
         if (globalTweekRepository) {


### PR DESCRIPTION
In many cases we have an extra validation we need to run on a tweek key, for example `num > 0`, or string is part of some enum.
Instead of doing this in the code logic, we want to have this in the tweek key, so this would result in a line like this:

```js
withTweekKeys('/support/routing/queue/item_presented_event/min_time_to_trigger', 
{propName: 'minimumViewTime',
{validateFunction: (val) => val > 0, defaultValue: 100}
}),
```