### PR TITLE
Remove polling from tweek-local-cache

### DIFF
--- a/js/tweek-local-cache/package.json
+++ b/js/tweek-local-cache/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tweek-local-cache",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "description": "Local cache to be used with tweek-client",
   "author": "Soluto",
   "license": "MIT",

--- a/js/tweek-local-cache/spec/unit/tweek-repository.spec.ts
+++ b/js/tweek-local-cache/spec/unit/tweek-repository.spec.ts
@@ -472,12 +472,13 @@ describe('tweek repo test', () => {
       await initialDelay;
 
       const refreshPromise = _tweekRepo.refresh(['key1']);
-      promises.push(refreshPromise);
-      promises.push(_tweekRepo.refresh(['key2', 'key3']));
 
       await refreshPromise;
 
       expect(fetchStub).to.have.been.calledOnce;
+
+      promises.push(refreshPromise);
+      promises.push(_tweekRepo.refresh(['key2', 'key3']));
 
       await Promise.all(promises);
 

--- a/js/tweek-local-cache/spec/unit/tweek-repository.spec.ts
+++ b/js/tweek-local-cache/spec/unit/tweek-repository.spec.ts
@@ -472,13 +472,12 @@ describe('tweek repo test', () => {
       await initialDelay;
 
       const refreshPromise = _tweekRepo.refresh(['key1']);
+      promises.push(refreshPromise);
+      promises.push(_tweekRepo.refresh(['key2', 'key3']));
 
       await refreshPromise;
 
       expect(fetchStub).to.have.been.calledOnce;
-
-      promises.push(refreshPromise);
-      promises.push(_tweekRepo.refresh(['key2', 'key3']));
 
       await Promise.all(promises);
 

--- a/js/tweek-local-cache/src/index.ts
+++ b/js/tweek-local-cache/src/index.ts
@@ -3,4 +3,4 @@ require('object.values').shim();
 
 export * from './types';
 export { default as MemoryStore } from './memory-store';
-export * from './tweek-repository';
+export { default as TweekRepository, TweekKeySplitJoin } from './tweek-repository';

--- a/js/tweek-local-cache/src/tweek-repository.ts
+++ b/js/tweek-local-cache/src/tweek-repository.ts
@@ -233,6 +233,7 @@ export default class TweekRepository {
   }
 
   private _refreshKeys() {
+    if (!this._isDirty) return Promise.resolve();
     this._isDirty = false;
 
     let expiredKeys = Object.entries(this._cache.list()).filter(
@@ -266,6 +267,7 @@ export default class TweekRepository {
             expiration: 'expired',
           }),
         );
+        this._isDirty = true;
         throw err;
       })
       .then(keyValues => this._updateTrieKeys(keysToRefresh, keyValues))

--- a/js/tweek-local-cache/src/tweek-repository.ts
+++ b/js/tweek-local-cache/src/tweek-repository.ts
@@ -45,14 +45,17 @@ export default class TweekRepository {
   private _refreshPromise: Promise<void>;
   private _nextRefreshPromise: Promise<void>;
 
-  constructor({ client, getPolicy, refreshInterval = 30, refreshDelay }: TweekRepositoryConfig) {
+  constructor({ client, getPolicy, refreshInterval, refreshDelay }: TweekRepositoryConfig) {
     this._client = client;
     this._store = new MemoryStore();
     this._getPolicy = { notReady: 'wait', notPrepared: 'prepare', ...TweekRepository._ensurePolicy(getPolicy) };
-    this._refreshDelay = refreshDelay || refreshInterval;
-
+    this._refreshDelay = refreshDelay || refreshInterval || 30;
     this._refreshPromise = Promise.resolve();
     this._nextRefreshPromise = Promise.resolve();
+
+    if (refreshInterval) {
+      console.warn("TweekRepository constructor argument 'refreshInterval' is deprecated.  Use 'refreshDelay' instead");
+    }
   }
 
   set context(value: Context) {

--- a/js/tweek-local-cache/src/tweek-repository.ts
+++ b/js/tweek-local-cache/src/tweek-repository.ts
@@ -38,18 +38,18 @@ export default class TweekRepository {
   private _client: ITweekClient;
   private _context: Context = {};
   private _getPolicy: GetPolicy;
-  private _refreshInterval: number;
+  private _refreshDelay: number;
   private _isDirty = false;
 
   private _refreshInProgress = false;
   private _refreshPromise: Promise<void>;
   private _nextRefreshPromise: Promise<void>;
 
-  constructor({ client, getPolicy, refreshInterval = 30 }: TweekRepositoryConfig) {
+  constructor({ client, getPolicy, refreshInterval = 30, refreshDelay }: TweekRepositoryConfig) {
     this._client = client;
     this._store = new MemoryStore();
     this._getPolicy = { notReady: 'wait', notPrepared: 'prepare', ...TweekRepository._ensurePolicy(getPolicy) };
-    this._refreshInterval = refreshInterval;
+    this._refreshDelay = refreshDelay || refreshInterval;
 
     this._refreshPromise = Promise.resolve();
     this._nextRefreshPromise = Promise.resolve();
@@ -216,7 +216,7 @@ export default class TweekRepository {
 
     this._refreshInProgress = true;
 
-    this._refreshPromise = delay(this._refreshInterval).then(() => this._refreshKeys());
+    this._refreshPromise = delay(this._refreshDelay).then(() => this._refreshKeys());
 
     this._nextRefreshPromise = this._refreshPromise
       .then(() => {

--- a/js/tweek-local-cache/src/types.ts
+++ b/js/tweek-local-cache/src/types.ts
@@ -45,6 +45,7 @@ export type TweekRepositoryConfig = {
   client: ITweekClient;
   getPolicy?: GetPolicy;
   refreshInterval?: number;
+  refreshDelay?: number;
 };
 
 export type GetPolicy = {


### PR DESCRIPTION
this PR removes the polling mechanism in `tweek-local-cache` and replaces it with the same functionality, but it gets initiated only when the cache is dirty.

It should retain the same functionality as before in regards to returning the correct promises for whether we should wait for the current refresh (`_refreshPromise`) or the next cycle's refresh (`_nextRefreshPromise`).


Reason for the change:

Ran into some problems with Detox testing after adding this cache.  The polling confuses the synchronization mechanisms in Detox (https://github.com/wix/detox/blob/master/docs/Troubleshooting.Synchronization.md).  Rather than scooting around the issue and making detox work, I thought it might be a good idea to remove the polling since it's not completely necessary.  Here's a snippet of the synchronization issue:

> **setTimeout and setInterval**
> By default, Detox is designed to ignore setInterval and will only wait for setTimeout of up to 1 second. If you have an endless polling loop with short intervals implemented with setTimeout, switch the implementation to setInterval. If possible, avoid agressive polling in your app altogether, the poor single JavaScript thread we have doesn't like it.
