### PR TITLE
Fix documentation

### DIFF
--- a/dotnet/Tweek.Client/README.md
+++ b/dotnet/Tweek.Client/README.md
@@ -63,7 +63,7 @@ public class AuthenticatedMessageHandler: DelegatingHandler
 
     protected override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
     {
-        var token = await mAuthorizationProvider.GetTokenAsync();
+        var token = await mAuthorizationProvider();
         request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", token);
         return await base.SendAsync(request, cancellationToken);
     }


### PR DESCRIPTION
The sample showing how to use Tweek dotnet authentication did not compile, I fixed it.