### PR TITLE
updated client

### DIFF
--- a/js/tweek-local-cache/package.json
+++ b/js/tweek-local-cache/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tweek-local-cache",
-  "version": "0.3.0-rc0",
+  "version": "0.3.0-rc1",
   "description": "Local cache to be used with tweek-client",
   "author": "Soluto",
   "license": "MIT",

--- a/js/tweek-local-cache/src/tweek-repository.ts
+++ b/js/tweek-local-cache/src/tweek-repository.ts
@@ -166,7 +166,9 @@ export default class TweekRepository {
 
   private checkRefresh() {
     this._refreshPromise = this._refreshInProgress
-      ? this._refreshPromise.then(x => this._rollRefresh())
+      ? this._refreshPromise.then(() => {
+          if (!this._refreshInProgress) return this._rollRefresh();
+        })
       : this._rollRefresh();
   }
 

--- a/js/tweek-local-cache/src/tweek-repository.ts
+++ b/js/tweek-local-cache/src/tweek-repository.ts
@@ -236,16 +236,10 @@ export default class TweekRepository {
 
     const promise = (this._retryCount === 0 ? delay(this._refreshDelay) : Promise.resolve())
       .then(() => this._refreshKeys())
-      .then(
-        () => {
-          this._refreshInProgress = false;
-          this._retryCount = 0;
-        },
-        ex => {
-          this._refreshInProgress = false;
-          throw ex;
-        },
-      );
+      .then(() => {
+        this._refreshInProgress = false;
+        this._retryCount = 0;
+      });
 
     promise.catch(ex => {
       this._refreshErrorPolicy(


### PR DESCRIPTION
Multiple refreshes could cause multiple refreshIntervalPolicy to run in parallel, this fix synchronize this behavior. (by removing refreshInProgress flag only after successful refresh)