### PR TITLE
Fix JavaScript Client

### DIFF
--- a/js/tweek-client/package.json
+++ b/js/tweek-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tweek-client",
-  "version": "0.1.14",
+  "version": "0.1.15",
   "description": "Tweek client for JavaScript",
   "author": "Soluto",
   "license": "MIT",

--- a/js/tweek-client/src/utils.ts
+++ b/js/tweek-client/src/utils.ts
@@ -5,11 +5,27 @@ export function captialize(string) {
   return string.charAt(0).toUpperCase() + string.slice(1);
 }
 
-export const createFetchWithTimeout = (timeout, fetch) => (input, init) =>
-  Promise.race([fetch(input, init), requestTimeout(timeout)]);
+export const createFetchWithTimeout = (timeoutInMillis, fetch) => (input, init): Promise<Response> => {
+  let timeout;
 
-export function requestTimeout(timeoutInMillis): Promise<Response> {
-  return new Promise(res => setTimeout(() => res(new Response(null, { status: 408 })), timeoutInMillis));
+  return Promise.race([
+    fetch(input, init),
+    new Promise(res => {
+      timeout = setTimeout(() =>
+        res(new Response(null, { status: 408 })),
+        timeoutInMillis
+      );
+
+      return timeout;
+    })
+  ])
+    .then((response) => {
+      if (timeout) {
+        clearTimeout(timeout);
+      }
+
+      return response;
+    });
 }
 
 export function snakeToCamelCase(target) {

--- a/js/tweek-client/src/utils.ts
+++ b/js/tweek-client/src/utils.ts
@@ -15,8 +15,6 @@ export const createFetchWithTimeout = (timeoutInMillis, fetch) => (input, init):
         res(new Response(null, { status: 408 })),
         timeoutInMillis
       );
-
-      return timeout;
     })
   ])
     .then((response) => {
@@ -25,6 +23,13 @@ export const createFetchWithTimeout = (timeoutInMillis, fetch) => (input, init):
       }
 
       return response;
+    })
+    .catch((error) => {
+      if (timeout) {
+        clearTimeout(timeout);
+      }
+
+      throw error;
     });
 }
 


### PR DESCRIPTION
Clear the fetch timeout when the fetch completes. Otherwise, the timeout will remain in the event loop, which, by default, will hang Lambdas.