### PR TITLE
`withTweekKeys` always calls `this.setState`

### DIFF
--- a/js/react-tweek/package.json
+++ b/js/react-tweek/package.json
@@ -14,7 +14,8 @@
     "tweek-local-cache": "^0.3.0"
   },
   "dependencies": {
-    "humps": "^2.0.1"
+    "humps": "^2.0.1",
+    "lodash.isequal": "^4.5.0"
   },
   "devDependencies": {
     "babel-cli": "^6.26.0",

--- a/js/react-tweek/package.json
+++ b/js/react-tweek/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-tweek",
-  "version": "0.2.4",
+  "version": "0.2.5",
   "description": "react bindings for tweek",
   "main": "./dist/index.js",
   "author": "Soluto",

--- a/js/react-tweek/src/withTweekKeys.js
+++ b/js/react-tweek/src/withTweekKeys.js
@@ -1,8 +1,12 @@
 import React, { Component } from 'react';
 import { camelize } from 'humps';
 import PropTypes from 'prop-types';
+import isEqual from 'lodash.isequal';
 
-export default (path, { mergeProps = true, propName, onError, repoKey = 'tweekRepo', getPolicy, once } = {}) => EnhancedComponent =>
+export default (
+  path,
+  { mergeProps = true, propName, onError, repoKey = 'tweekRepo', getPolicy, once } = {},
+) => EnhancedComponent =>
   class extends Component {
     static displayName = `withTweekKeys(${EnhancedComponent.displayName || EnhancedComponent.name || 'Component'})`;
     static contextTypes = {
@@ -16,7 +20,7 @@ export default (path, { mergeProps = true, propName, onError, repoKey = 'tweekRe
         start: subscription => (this.subscription = subscription),
         next: result => {
           this.setTweekValue(result);
-          if(once) {
+          if (once) {
             this.unsubscribe();
           }
         },
@@ -48,10 +52,11 @@ export default (path, { mergeProps = true, propName, onError, repoKey = 'tweekRe
           ? { [propName || camelize(configName)]: result.value }
           : { [propName || 'tweek']: { [camelize(configName)]: result.value } };
       }
+      if (isEqual(this.state.tweekProps, tweekProps)) return;
       this.setState({ tweekProps });
     };
 
     render() {
       return this.state.tweekProps ? <EnhancedComponent {...this.props} {...this.state.tweekProps} /> : null;
     }
-  }
+  };


### PR DESCRIPTION
even when it didn't change.
This will trigger the render func on the child component even when not needed.