### PR TITLE
ignore redundant renders in withTweekKeys

### DIFF
--- a/js/react-tweek/package.json
+++ b/js/react-tweek/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-tweek",
-  "version": "0.2.5",
+  "version": "0.2.6",
   "description": "react bindings for tweek",
   "main": "./dist/index.js",
   "author": "Soluto",

--- a/js/react-tweek/src/withTweekKeys.js
+++ b/js/react-tweek/src/withTweekKeys.js
@@ -56,7 +56,6 @@ export default (
     };
 
     shouldComponentUpdate(nextProps, nextState) {
-      if (!this.state || !nextState) return !isEqual(this.props, nextProps) || this.state != nextState;
       return !isEqual(this.props, nextProps) || !isEqual(this.state.tweekProps, nextState.tweekProps);
     }
 

--- a/js/react-tweek/src/withTweekKeys.js
+++ b/js/react-tweek/src/withTweekKeys.js
@@ -52,9 +52,13 @@ export default (
           ? { [propName || camelize(configName)]: result.value }
           : { [propName || 'tweek']: { [camelize(configName)]: result.value } };
       }
-      if (isEqual(this.state.tweekProps, tweekProps)) return;
       this.setState({ tweekProps });
     };
+
+    shouldComponentUpdate(nextProps, nextState) {
+      if (!this.state || !nextState) return !isEqual(this.props, nextProps) || this.state != nextState;
+      return !isEqual(this.props, nextProps) || !isEqual(this.state.tweekProps, nextState.tweekProps);
+    }
 
     render() {
       return this.state.tweekProps ? <EnhancedComponent {...this.props} {...this.state.tweekProps} /> : null;


### PR DESCRIPTION
update only when `props` or `state.tweekProps` are changed