### PR TITLE
Fix react-tweek bug

### DIFF
--- a/js/react-tweek/package.json
+++ b/js/react-tweek/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-tweek",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "description": "react bindings for tweek",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/js/react-tweek/src/withTweekKeysFactory.tsx
+++ b/js/react-tweek/src/withTweekKeysFactory.tsx
@@ -51,7 +51,7 @@ export class WithTweekKeysComponent extends Component<WithTweekKeysRepoProps, Wi
         result => {
           this.setState((state) => {
             if (!isScanKey) {
-              result = result.value;
+              result = result.hasValue ? result.value : null;
             }
             if (isEqual(state[propName], result)) {
               return null;


### PR DESCRIPTION
when a key is missing the component didn't render at all, now it will pass null instead