### PR TITLE
Improve cache

### DIFF
--- a/js/react-tweek/package.json
+++ b/js/react-tweek/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-tweek",
-  "version": "0.5.2",
+  "version": "0.6.0",
   "description": "react bindings for tweek",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
@@ -11,7 +11,7 @@
   "peerDependencies": {
     "prop-types": "^15.0.0",
     "react": "^16.3.0",
-    "tweek-local-cache": "^0.5.0"
+    "tweek-local-cache": "^0.6.0"
   },
   "dependencies": {
     "lodash.isequal": "^4.5.0"
@@ -26,7 +26,7 @@
     "react-test-renderer": "^16.3.0",
     "rimraf": "^2.6.3",
     "ts-jest": "^23.10.5",
-    "tweek-local-cache": "^0.5.0",
+    "tweek-local-cache": "^0.6.0",
     "typescript": "^3.3.1"
   },
   "scripts": {

--- a/js/react-tweek/src/createTweekContext.test.tsx
+++ b/js/react-tweek/src/createTweekContext.test.tsx
@@ -1,13 +1,19 @@
 import React from 'react';
 import renderer from 'react-test-renderer';
+import { TweekRepository } from 'tweek-local-cache';
 import { createTweekContext } from './createTweekContext';
 
 describe('createTweekContext', () => {
+  let repository: TweekRepository;
+  beforeEach(() => {
+    repository = new TweekRepository({ client: {} as any });
+  });
+
   test('default provider should prepare keys when prepare is called', () => {
-    const prepare = jest.fn();
+    const prepare = jest.spyOn(repository, 'prepare');
     const key = 'some_key_path';
 
-    const context = createTweekContext({ prepare } as any);
+    const context = createTweekContext(repository);
 
     context.prepareKey(key);
 
@@ -15,22 +21,24 @@ describe('createTweekContext', () => {
   });
 
   test('generated provider should prepare requested keys', () => {
-    const prepare = jest.fn();
+    const otherRepository = new TweekRepository({ client: {} as any });
+    const prepare = jest.spyOn(otherRepository, 'prepare');
     const key = 'some_key_path';
 
-    const Context = createTweekContext({ prepare: jest.fn() } as any);
+    const Context = createTweekContext(repository);
     Context.prepareKey(key);
-    renderer.create(<Context.Provider value={{ prepare } as any} />);
+    renderer.create(<Context.Provider value={otherRepository} />);
 
     expect(prepare).toHaveBeenCalledWith(key);
   });
 
   test('generated provider should prepare keys after render', () => {
-    const prepare = jest.fn();
+    const otherRepository = new TweekRepository({ client: {} as any });
+    const prepare = jest.spyOn(otherRepository, 'prepare');
     const key = 'some_key_path';
 
-    const Context = createTweekContext({ prepare: jest.fn() } as any);
-    renderer.create(<Context.Provider value={{ prepare } as any} />);
+    const Context = createTweekContext(repository);
+    renderer.create(<Context.Provider value={otherRepository} />);
     Context.prepareKey(key);
 
     expect(prepare).toHaveBeenCalledWith(key);

--- a/js/react-tweek/src/createUseTweekValue.ts
+++ b/js/react-tweek/src/createUseTweekValue.ts
@@ -43,18 +43,16 @@ export const createUseTweekValue = (
     ensureHooks();
 
     const tweekRepository = React.useContext(TweekContext);
-    const [tweekValue, setTweekValue] = React.useReducer<Reducer<T, T>, null>(valueReducer, null, () =>
-      getValueOrDefault(tweekRepository, keyPath, defaultValue),
-    );
+    const getTweekValue = () => getValueOrDefault(tweekRepository, keyPath, defaultValue);
+    const [tweekValue, setTweekValue] = React.useReducer<Reducer<T, T>, null>(valueReducer, null, getTweekValue);
 
     React.useEffect(() => {
-      const updateValue = () => setTweekValue(getValueOrDefault(tweekRepository, keyPath, defaultValue));
-      updateValue();
+      setTweekValue(getTweekValue());
       return (
         tweekRepository &&
         tweekRepository.listen(updatedKeys => {
           if (updatedKeys.has(keyPath)) {
-            updateValue();
+            setTweekValue(getTweekValue());
           }
         })
       );

--- a/js/tweek-local-cache/package.json
+++ b/js/tweek-local-cache/package.json
@@ -10,6 +10,7 @@
   "types": "./dist/index.d.ts",
   "dependencies": {
     "change-emitter": "^0.1.6",
+    "lodash.isequal": "^4.5.0",
     "object.entries": "^1.1.0",
     "object.values": "^1.1.0",
     "symbol-observable": "^1.0.4",

--- a/js/tweek-local-cache/package.json
+++ b/js/tweek-local-cache/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tweek-local-cache",
-  "version": "0.5.2",
+  "version": "0.6.0",
   "description": "Local cache to be used with tweek-client",
   "author": "Soluto",
   "license": "MIT",

--- a/js/tweek-local-cache/spec/behavior/tweek-repository.spec.ts
+++ b/js/tweek-local-cache/spec/behavior/tweek-repository.spec.ts
@@ -131,17 +131,10 @@ describe('tweek repo behavior test', function(this: Mocha.Suite) {
       // Act
       _tweekRepo.expire();
       await (<any>_tweekRepo)._waitRefreshCycle();
+      const values = await Promise.all(test.expectedKeys.map(x => _tweekRepo.getValue(x.keyName)));
 
       // Assert
-      const getKeysValuesPromises: Promise<any>[] = test.expectedKeys.map(x => _tweekRepo.getValue(x.keyName));
-
-      try {
-        const values = await Promise.all(getKeysValuesPromises);
-        values.forEach((x, index) => expect(x.value).to.eql(test.expectedKeys[index], 'should have correct value'));
-      } catch (ex) {
-        console.log('failed getting keys');
-        throw ex;
-      }
+      expect(values).to.deep.equal(test.expectedKeys.map(x => x.value));
     }),
   );
 });

--- a/js/tweek-local-cache/spec/behavior/tweek-repository.spec.ts
+++ b/js/tweek-local-cache/spec/behavior/tweek-repository.spec.ts
@@ -129,17 +129,15 @@ describe('tweek repo behavior test', function(this: Mocha.Suite) {
       test.pathsToPrepare.forEach(x => _tweekRepo.prepare(x));
 
       // Act
-      _tweekRepo.refresh();
+      _tweekRepo.expire();
       await (<any>_tweekRepo)._waitRefreshCycle();
 
       // Assert
-      const getKeysValuesPromises: Promise<any>[] = test.expectedKeys.map(x => _tweekRepo.get(x.keyName));
+      const getKeysValuesPromises: Promise<any>[] = test.expectedKeys.map(x => _tweekRepo.getValue(x.keyName));
 
       try {
         const values = await Promise.all(getKeysValuesPromises);
-        values.forEach((x, index) =>
-          expect(x.value).to.eql(test.expectedKeys[index].value, 'should have correct value'),
-        );
+        values.forEach((x, index) => expect(x.value).to.eql(test.expectedKeys[index], 'should have correct value'));
       } catch (ex) {
         console.log('failed getting keys');
         throw ex;

--- a/js/tweek-local-cache/spec/unit/tweek-repository.spec.ts
+++ b/js/tweek-local-cache/spec/unit/tweek-repository.spec.ts
@@ -48,25 +48,6 @@ describe('tweek repo test', () => {
     await (<any>_tweekRepo)._waitRefreshCycle();
   }
 
-  function observeKey(key: string, count = 1): Promise<any[]> {
-    return new Promise((resolve, reject) => {
-      const items: any[] = [];
-      const subscription = _tweekRepo.observe(key).subscribe({
-        next: value => {
-          items.push(value);
-          if (items.length === count) {
-            subscription.unsubscribe();
-            resolve(items);
-          }
-        },
-        error: err => {
-          subscription.unsubscribe();
-          reject(err);
-        },
-      });
-    });
-  }
-
   async function initRepository({ store, client = _defaultClient, context }: InitRepoConfig = {}) {
     _tweekRepo = new TweekRepository({ client, refreshDelay: 2, context });
     if (store) {
@@ -111,127 +92,276 @@ describe('tweek repo test', () => {
   });
 
   describe('retrieve', () => {
-    it('should get single key', async () => {
-      // Arrange
-      await initRepository();
+    describe('deprecated get', () => {
+      it('should get single key', async () => {
+        // Arrange
+        await initRepository();
 
-      await _tweekRepo.prepare('my_path/string_value');
-      await _tweekRepo.prepare('my_path/inner_path_1/int_value');
-      await _tweekRepo.prepare('my_path/inner_path_1/bool_positive_value');
-      await _tweekRepo.prepare('my_path/inner_path_2/bool_negative_value');
+        await _tweekRepo.prepare('my_path/string_value');
+        await _tweekRepo.prepare('my_path/inner_path_1/int_value');
+        await _tweekRepo.prepare('my_path/inner_path_1/bool_positive_value');
+        await _tweekRepo.prepare('my_path/inner_path_2/bool_negative_value');
 
-      await refreshAndWait();
+        await refreshAndWait();
 
-      // Act
-      let key1 = await _tweekRepo.get('my_path/string_value');
-      let key2 = await _tweekRepo.get('my_path/inner_path_1/int_value');
-      let key3 = await _tweekRepo.get('my_path/inner_path_1/bool_positive_value');
-      let key4 = await _tweekRepo.get('my_path/inner_path_2/bool_negative_value');
+        // Act
+        let key1 = await _tweekRepo.get('my_path/string_value');
+        let key2 = await _tweekRepo.get('my_path/inner_path_1/int_value');
+        let key3 = await _tweekRepo.get('my_path/inner_path_1/bool_positive_value');
+        let key4 = await _tweekRepo.get('my_path/inner_path_2/bool_negative_value');
 
-      // Assert
-      expect(key1.value).to.equal('my-string');
-      expect(key2.value).to.equal(55);
-      expect(key3.value).to.equal(true);
-      expect(key4.value).to.equal(false);
+        // Assert
+        expect(key1.value).to.equal('my-string');
+        expect(key2.value).to.equal(55);
+        expect(key3.value).to.equal(true);
+        expect(key4.value).to.equal(false);
+      });
+
+      it('should get keys node', async () => {
+        // Arrange
+        await initRepository();
+
+        await _tweekRepo.prepare('some_path/_');
+        await refreshAndWait();
+
+        const expectedKeysNode = {
+          innerPath1: {
+            firstValue: 'value_1',
+            secondValue: 'value_2',
+          },
+        };
+
+        // Act
+        let keysNode = await _tweekRepo.get('some_path/_');
+
+        // Assert
+        expect(keysNode).to.deep.equal(expectedKeysNode);
+      });
+
+      it('should get scan result', async () => {
+        // Arrange
+        await initRepository();
+        await _tweekRepo.prepare('some_path/_');
+        await refreshAndWait();
+
+        // Act
+        let config = await _tweekRepo.get('some_path/_');
+
+        // Assert
+        expect(config.innerPath1.firstValue).to.equal('value_1');
+        expect(config.innerPath1.secondValue).to.equal('value_2');
+      });
+
+      it('should get scan result deeply nested', async () => {
+        // Arrange
+        await initRepository();
+        await _tweekRepo.prepare('deeply_nested/_');
+        await refreshAndWait();
+
+        // Act
+        let config = await _tweekRepo.get('deeply_nested/a/b/_');
+
+        // Assert
+        expect(config.c.d.value).to.equal('value_5');
+      });
+
+      it('should get root scan', async () => {
+        // Arrange
+        await initRepository();
+        await _tweekRepo.prepare('_');
+        await refreshAndWait();
+
+        // Act
+        let config = await _tweekRepo.get('_');
+
+        // Assert
+        expect(config.innerPath1.firstValue).to.equal('value_1');
+      });
+
+      it('should get single key after scan prepare', async () => {
+        // Arrange
+        await initRepository();
+        _tweekRepo.prepare('some_path/_');
+
+        await refreshAndWait();
+
+        // Act
+        let key = await _tweekRepo.get('some_path/inner_path_1/first_value');
+
+        // Assert
+        expect(key.value).to.eql('value_1');
+      });
+
+      it('should be case insensitive', async () => {
+        // Arrange
+        await initRepository();
+
+        await _tweekRepo.prepare('my_Path/string_value');
+        await _tweekRepo.prepare('my_path/inneR_path_1/int_value');
+        await _tweekRepo.prepare('my_path/inner_path_1/bool_Positive_value');
+        await _tweekRepo.prepare('my_path/inner_path_2/bool_negative_Value');
+
+        await refreshAndWait();
+
+        // Act
+        let key1 = await _tweekRepo.get('My_path/string_value');
+        let key2 = await _tweekRepo.get('my_Path/inner_path_1/int_value');
+        let key3 = await _tweekRepo.get('my_path/Inner_path_1/bool_positive_value');
+        let key4 = await _tweekRepo.get('my_path/inner_path_2/Bool_negative_value');
+
+        // Assert
+        expect(key1.value).to.equal('my-string');
+        expect(key2.value).to.equal(55);
+        expect(key3.value).to.equal(true);
+        expect(key4.value).to.equal(false);
+      });
     });
 
-    it('should get keys node', async () => {
-      // Arrange
-      await initRepository();
+    describe('getValue', () => {
+      it('should get single key', async () => {
+        // Arrange
+        await initRepository();
 
-      await _tweekRepo.prepare('some_path/_');
-      await refreshAndWait();
+        const expected = {
+          'my_path/string_value': 'my-string',
+          'my_path/inner_path_1/int_value': 55,
+          'my_path/inner_path_1/bool_positive_value': true,
+          'my_path/inner_path_2/bool_negative_value': false,
+        };
 
-      const expectedKeysNode = {
-        innerPath1: {
-          firstValue: 'value_1',
-          secondValue: 'value_2',
-        },
-      };
+        await Promise.all(Object.keys(expected).map(key => _tweekRepo.prepare(key)));
 
-      // Act
-      let keysNode = await _tweekRepo.get('some_path/_');
+        await refreshAndWait();
 
-      // Assert
-      expect(keysNode).to.deep.equal(expectedKeysNode);
-    });
+        for (const [key, expectedValue] of Object.entries(expected)) {
+          // Act
+          const value = await _tweekRepo.getValue(key);
 
-    it('should get scan result', async () => {
-      // Arrange
-      await initRepository();
-      await _tweekRepo.prepare('some_path/_');
-      await refreshAndWait();
+          // Assert
+          expect(value).to.equal(expectedValue);
+        }
+      });
 
-      // Act
-      let config = await _tweekRepo.get('some_path/_');
+      it('should get keys node', async () => {
+        // Arrange
+        await initRepository();
 
-      // Assert
-      expect(config.innerPath1.firstValue).to.equal('value_1');
-      expect(config.innerPath1.secondValue).to.equal('value_2');
-    });
+        await _tweekRepo.prepare('some_path/_');
+        await refreshAndWait();
 
-    it('should get scan result deeply nested', async () => {
-      // Arrange
-      await initRepository();
-      await _tweekRepo.prepare('deeply_nested/_');
-      await refreshAndWait();
+        const expectedKeysNode = {
+          innerPath1: {
+            firstValue: 'value_1',
+            secondValue: 'value_2',
+          },
+        };
 
-      // Act
-      let config = await _tweekRepo.get('deeply_nested/a/b/_');
+        // Act
+        const value = await _tweekRepo.getValue('some_path/_');
 
-      // Assert
-      expect(config.c.d.value).to.equal('value_5');
-    });
+        // Assert
+        expect(value).to.deep.equal(expectedKeysNode);
+      });
 
-    it('should get root scan', async () => {
-      // Arrange
-      await initRepository();
-      await _tweekRepo.prepare('_');
-      await refreshAndWait();
+      it('should get scan result', async () => {
+        // Arrange
+        await initRepository();
+        await _tweekRepo.prepare('some_path/_');
+        await refreshAndWait();
 
-      // Act
-      let config = await _tweekRepo.get('_');
+        // Act
+        const value = await _tweekRepo.getValue('some_path/_');
 
-      // Assert
-      expect(config.innerPath1.firstValue).to.equal('value_1');
-    });
+        // Assert
+        expect(value).to.deep.include({
+          innerPath1: {
+            firstValue: 'value_1',
+            secondValue: 'value_2',
+          },
+        });
+      });
 
-    it('should get single key after scan prepare', async () => {
-      // Arrange
-      await initRepository();
-      _tweekRepo.prepare('some_path/_');
+      it('should get scan result deeply nested', async () => {
+        // Arrange
+        await initRepository();
+        await _tweekRepo.prepare('deeply_nested/_');
+        await refreshAndWait();
 
-      await refreshAndWait();
+        // Act
+        const value = await _tweekRepo.getValue('deeply_nested/a/b/_');
 
-      // Act
-      let key = await _tweekRepo.get('some_path/inner_path_1/first_value');
+        // Assert
+        expect(value).to.deep.include({ c: { d: { value: 'value_5' } } });
+      });
 
-      // Assert
-      expect(key.value).to.eql('value_1');
-    });
+      it('should get root scan', async () => {
+        // Arrange
+        await initRepository();
+        await _tweekRepo.prepare('_');
+        await refreshAndWait();
 
-    it('should be case insensitive', async () => {
-      // Arrange
-      await initRepository();
+        // Act
+        const value = await _tweekRepo.getValue('_');
 
-      await _tweekRepo.prepare('my_Path/string_value');
-      await _tweekRepo.prepare('my_path/inneR_path_1/int_value');
-      await _tweekRepo.prepare('my_path/inner_path_1/bool_Positive_value');
-      await _tweekRepo.prepare('my_path/inner_path_2/bool_negative_Value');
+        // Assert
+        expect(value)
+          .to.have.property('innerPath1')
+          .that.deep.include({ firstValue: 'value_1' });
+      });
 
-      await refreshAndWait();
+      it('should get single key after scan prepare', async () => {
+        // Arrange
+        await initRepository();
+        _tweekRepo.prepare('some_path/_');
 
-      // Act
-      let key1 = await _tweekRepo.get('My_path/string_value');
-      let key2 = await _tweekRepo.get('my_Path/inner_path_1/int_value');
-      let key3 = await _tweekRepo.get('my_path/Inner_path_1/bool_positive_value');
-      let key4 = await _tweekRepo.get('my_path/inner_path_2/Bool_negative_value');
+        await refreshAndWait();
 
-      // Assert
-      expect(key1.value).to.equal('my-string');
-      expect(key2.value).to.equal(55);
-      expect(key3.value).to.equal(true);
-      expect(key4.value).to.equal(false);
+        // Act
+        const value = await _tweekRepo.getValue('some_path/inner_path_1/first_value');
+
+        // Assert
+        expect(value).to.eql('value_1');
+      });
+
+      it('should get missing key', async () => {
+        // Arrange
+        await initRepository();
+        await _tweekRepo.prepare('some_path/missing_key');
+        await refreshAndWait();
+
+        // Act
+        const value = await _tweekRepo.getValue('some_path/missing_key');
+
+        // Assert
+        expect(value).to.eql(undefined);
+      });
+
+      it('should be case insensitive', async () => {
+        // Arrange
+        await initRepository();
+
+        await _tweekRepo.prepare('my_Path/string_value');
+        await _tweekRepo.prepare('my_path/inneR_path_1/int_value');
+        await _tweekRepo.prepare('my_path/inner_path_1/bool_Positive_value');
+        await _tweekRepo.prepare('my_path/inner_path_2/bool_negative_Value');
+
+        await refreshAndWait();
+
+        const expected = {
+          'My_path/string_value': 'my-string',
+          'my_Path/inner_patH_1/int_value': 55,
+          'my_path/Inner_path_1/bool_positive_value': true,
+          'my_path/inner_path_2/Bool_negative_value': false,
+        };
+
+        for (const [key, expectedValue] of Object.entries(expected)) {
+          // Act
+          const value = await _tweekRepo.getValue(key);
+
+          // Assert
+          expect(value).to.equal(expectedValue);
+        }
+      });
     });
   });
 
@@ -261,10 +391,10 @@ describe('tweek repo test', () => {
       await initRepository({ store });
 
       // Act
-      let key = await _tweekRepo.get('some_path/inner_path_1/first_value');
+      const value = await _tweekRepo.getValue('some_path/inner_path_1/first_value');
 
       // Assert
-      expect(key.value).to.equal('value_1');
+      expect(value).to.equal('value_1');
     });
 
     it('should load persisted scan', async () => {
@@ -279,10 +409,10 @@ describe('tweek repo test', () => {
       await initRepository({ store });
 
       // Act & Assert
-      const result1 = await _tweekRepo.get('some_path/inner_path_1/_');
+      const result1 = await _tweekRepo.getValue('some_path/inner_path_1/_');
       expect(result1).to.eql({ firstValue: 'value_1', secondValue: 'value_2' });
 
-      const result2 = await _tweekRepo.get('some_path/_');
+      const result2 = await _tweekRepo.getValue('some_path/_');
       expect(result2).to.eql({ innerPath1: { firstValue: 'value_1', secondValue: 'value_2' } });
     });
 
@@ -296,14 +426,25 @@ describe('tweek repo test', () => {
       await initRepository({ store });
 
       // Act & assert
-      let old = await _tweekRepo.get('some_path/inner_path_1/first_value');
-      expect(old.value).to.eql('old_value');
+      const old = await _tweekRepo.getValue('some_path/inner_path_1/first_value');
+      expect(old).to.eql('old_value');
 
       await refreshAndWait();
       await new Promise(setImmediate);
 
-      let _new = await _tweekRepo.get('some_path/inner_path_1/first_value');
-      expect(_new.value).to.eql('value_1');
+      const _new = await _tweekRepo.getValue('some_path/inner_path_1/first_value');
+      expect(_new).to.eql('value_1');
+    });
+
+    it('should call error when store is corrupted', async () => {
+      // Arrange
+      await initRepository();
+
+      // Act
+      const loadPromise = _tweekRepo.useStore(new MemoryStore({ 'some_path/key': cachedItem() }));
+
+      //Assert
+      await expect(loadPromise).to.be.rejected;
     });
   });
 
@@ -315,16 +456,16 @@ describe('tweek repo test', () => {
       };
       _tweekRepo.addKeys(keys);
 
-      const result1 = await _tweekRepo.get('some_path/inner_path_1/first_value');
-      expect(result1.value).to.eql('default_value');
+      const result1 = await _tweekRepo.getValue('some_path/inner_path_1/first_value');
+      expect(result1).to.eql('default_value');
 
       await refreshAndWait();
-      const result2 = await _tweekRepo.get('some_path/inner_path_1/first_value');
-      expect(result2.value).to.eql('value_1');
+      const result2 = await _tweekRepo.getValue('some_path/inner_path_1/first_value');
+      expect(result2).to.eql('value_1');
     });
   });
 
-  describe('refresh', () => {
+  describe('expire', () => {
     it('should not do fetch request if there are no requested keys', async () => {
       // Arrange
       const fetchStub = sinon.stub();
@@ -397,10 +538,10 @@ describe('tweek repo test', () => {
 
       //Act
       await refreshAndWait();
-      const key = await _tweekRepo.get('some_key/should_be_removed');
+      const key = await _tweekRepo.getValue('some_key/should_be_removed');
 
       //Assert
-      expect(key).to.deep.include({ value: undefined, hasValue: false });
+      expect(key).to.eql(undefined);
     });
 
     it('should refresh expired keys when using store', async () => {
@@ -414,15 +555,19 @@ describe('tweek repo test', () => {
       await initRepository({ store });
       await refreshAndWait(['some_path/inner_path_1/first_value']);
 
-      // Act
-      let key1 = await _tweekRepo.get('my_path/string_value');
-      let key2 = await _tweekRepo.get('my_path/inner_path_1/int_value');
-      let key3 = await _tweekRepo.get('some_path/inner_path_1/first_value');
+      const expected = {
+        'my_path/string_value': 'my-string',
+        'my_path/inner_path_1/int_value': 55,
+        'some_path/inner_path_1/first_value': 'value_1',
+      };
 
-      // Assert
-      expect(key1.value).to.equal('my-string');
-      expect(key2.value).to.equal(55);
-      expect(key3.value).to.equal('value_1');
+      for (const [key, expectedValue] of Object.entries(expected)) {
+        // Act
+        const value = await _tweekRepo.getValue(key);
+
+        // Assert
+        expect(value).to.equal(expectedValue);
+      }
     });
 
     it('should batch all the refresh requests together', async () => {
@@ -449,7 +594,7 @@ describe('tweek repo test', () => {
 
       sinon.assert.calledOnce(fetchStub);
 
-      _tweekRepo.refresh(['key1']);
+      _tweekRepo.expire(['key1']);
       await refreshAndWait(['key2', 'key3']);
 
       sinon.assert.calledTwice(fetchStub);
@@ -482,8 +627,8 @@ describe('tweek repo test', () => {
 
       await Promise.all(
         Object.keys(persistedNodes).map(async key => {
-          const keyValue = await _tweekRepo.get(key);
-          expect(keyValue.value).to.equal(1);
+          const keyValue = await _tweekRepo.getValue(key);
+          expect(keyValue).to.equal(1);
         }),
       );
 
@@ -492,8 +637,8 @@ describe('tweek repo test', () => {
 
       await Promise.all(
         Object.keys(persistedNodes).map(async key => {
-          const keyValue = await _tweekRepo.get(key);
-          expect(keyValue.value).to.equal(2);
+          const keyValue = await _tweekRepo.getValue(key);
+          expect(keyValue).to.equal(2);
         }),
       );
     });
@@ -515,7 +660,7 @@ describe('tweek repo test', () => {
 
       await initRepository({ client: clientMock, store });
       _tweekRepo.addKeys({ test1: 0 });
-      const readValue = async () => (await _tweekRepo.get('test1')).value;
+      const readValue = () => _tweekRepo.getValue('test1');
 
       let recover: Function;
       let retryCounts: number[] = [];
@@ -567,7 +712,7 @@ describe('tweek repo test', () => {
       };
 
       (<any>_tweekRepo)._refreshErrorPolicy = policy;
-      const readValue = async () => (await _tweekRepo.get('test1')).value;
+      const readValue = () => _tweekRepo.getValue('test1');
 
       expect(await readValue()).to.eql(0);
       await refreshAndWait();
@@ -598,7 +743,26 @@ describe('tweek repo test', () => {
     });
   });
 
-  describe('observe', () => {
+  describe('deprecated observe', () => {
+    function observeKey(key: string, count = 1): Promise<any[]> {
+      return new Promise((resolve, reject) => {
+        const items: any[] = [];
+        const subscription = _tweekRepo.observe(key).subscribe({
+          next: value => {
+            items.push(value);
+            if (items.length === count) {
+              subscription.unsubscribe();
+              resolve(items);
+            }
+          },
+          error: err => {
+            subscription.unsubscribe();
+            reject(err);
+          },
+        });
+      });
+    }
+
     it('should observe single key', async () => {
       // Arrange
       await initRepository();
@@ -698,17 +862,6 @@ describe('tweek repo test', () => {
       expect(keys.map(x => x.value)).to.deep.equal(['old-value', 'my-string']);
     });
 
-    it('should call error when store is corrupted', async () => {
-      // Arrange
-      await initRepository({ store: new MemoryStore({ 'some_path/key': cachedItem() }) });
-
-      // Act
-      const keysPromise = observeKey('some_path/key', 1);
-
-      //Assert
-      await expect(keysPromise).to.be.rejected;
-    });
-
     it('should stop notifying after unsubscribe', async () => {
       const persistedNodes = {
         'my_path/string_value': cachedItem('old-value'),
@@ -729,6 +882,264 @@ describe('tweek repo test', () => {
 
       expect(items).to.have.lengthOf(1);
       expect(items).to.deep.equal(['old-value']);
+    });
+  });
+
+  describe('observeValue', () => {
+    function observeKey(key: string, count = 1): Promise<any[]> {
+      return new Promise((resolve, reject) => {
+        const items: any[] = [];
+        const subscription = _tweekRepo.observeValue(key).subscribe({
+          next: value => {
+            items.push(value);
+            if (items.length === count) {
+              subscription.unsubscribe();
+              resolve(items);
+            }
+          },
+          error: err => {
+            subscription.unsubscribe();
+            reject(err);
+          },
+        });
+      });
+    }
+
+    it('should observe single key', async () => {
+      // Arrange
+      await initRepository();
+
+      const expected = {
+        'my_path/string_value': 'my-string',
+        'my_path/inner_path_1/int_value': 55,
+        'my_path/inner_path_1/bool_positive_value': true,
+        'my_path/inner_path_2/bool_negative_value': false,
+      };
+
+      await Promise.all(Object.keys(expected).map(key => _tweekRepo.prepare(key)));
+
+      await refreshAndWait();
+
+      for (const [key, expectedValue] of Object.entries(expected)) {
+        // Act
+        const [value] = await observeKey(key);
+
+        // Assert
+        expect(value).to.equal(expectedValue);
+      }
+    });
+
+    it('should observe scan key', async () => {
+      // Arrange
+      await initRepository();
+
+      await _tweekRepo.prepare('some_path/_');
+      await refreshAndWait();
+
+      const expectedKeysNode = {
+        innerPath1: {
+          firstValue: 'value_1',
+          secondValue: 'value_2',
+        },
+      };
+
+      // Act
+      let [keysNode] = await observeKey('some_path/_');
+
+      // Assert
+      expect(keysNode).to.deep.equal(expectedKeysNode);
+    });
+
+    it('should observe root scan', async () => {
+      // Arrange
+      await initRepository();
+      await _tweekRepo.prepare('_');
+      await refreshAndWait();
+
+      // Act
+      let [config] = await observeKey('_');
+
+      // Assert
+      expect(config)
+        .to.have.property('innerPath1')
+        .that.deep.include({ firstValue: 'value_1' });
+    });
+
+    it('should be case insensitive', async () => {
+      // Arrange
+      await initRepository();
+
+      await _tweekRepo.prepare('my_Path/string_value');
+      await _tweekRepo.prepare('my_path/inneR_path_1/int_value');
+      await _tweekRepo.prepare('my_path/inner_path_1/bool_Positive_value');
+      await _tweekRepo.prepare('my_path/inner_path_2/bool_negative_Value');
+
+      await refreshAndWait();
+
+      const expected = {
+        'My_path/string_value': 'my-string',
+        'my_Path/inner_patH_1/int_value': 55,
+        'my_path/Inner_path_1/bool_positive_value': true,
+        'my_path/inner_path_2/Bool_negative_value': false,
+      };
+
+      for (const [key, expectedValue] of Object.entries(expected)) {
+        // Act
+        const [value] = await observeKey(key);
+
+        // Assert
+        expect(value).to.equal(expectedValue);
+      }
+    });
+
+    it('should notify after refresh new value', async () => {
+      // Arrange
+      const persistedNodes = {
+        'my_path/string_value': cachedItem('old-value'),
+      };
+      const store = new MemoryStore(persistedNodes);
+      await initRepository({ store });
+
+      // Act
+      const valuesPromise = observeKey('my_path/string_value', 2);
+      await refreshAndWait();
+
+      // Assert
+      const values = await valuesPromise;
+      expect(values).to.have.lengthOf(2);
+      expect(values).to.deep.equal(['old-value', 'my-string']);
+    });
+
+    it('should stop notifying after unsubscribe', async () => {
+      // Arrange
+      const persistedNodes = {
+        'my_path/string_value': cachedItem('old-value'),
+      };
+      const store = new MemoryStore(persistedNodes);
+      await initRepository({ store });
+
+      const items: any[] = [];
+      const subscription: ZenObservable.Subscription = _tweekRepo.observeValue('my_path/string_value').subscribe(
+        x => {
+          items.push(x);
+          subscription.unsubscribe();
+        },
+        () => subscription.unsubscribe(),
+      );
+
+      // Act
+      await refreshAndWait();
+
+      // Assert
+      expect(items).to.have.lengthOf(1);
+      expect(items).to.deep.equal(['old-value']);
+    });
+
+    it('should notify only on updated keys', async () => {
+      // Arrange
+      await initRepository();
+      const callback = sinon.stub();
+      const subscription = _tweekRepo.observeValue('my_path/string_value').subscribe(callback);
+
+      // Act
+      for (let i = 0; i < 5; i++) {
+        await refreshAndWait(['my_path/string_value']);
+      }
+
+      subscription.unsubscribe();
+
+      // Assert
+      sinon.assert.calledOnce(callback);
+    });
+  });
+
+  describe('listen', () => {
+    it('should notify on addKeys', async () => {
+      // Arrange
+      await initRepository();
+      const callback = sinon.stub();
+      const unlisten = _tweekRepo.listen(callback);
+
+      // Act
+      _tweekRepo.addKeys({ 'some/key/path': 'some value' });
+      unlisten();
+
+      // Assert
+      sinon.assert.calledOnce(callback);
+      sinon.assert.calledWithExactly(callback, ['some/key/path', 'some/_', 'some/key/_']);
+    });
+
+    it('should notify on useStore', async () => {
+      // Arrange
+      await initRepository();
+      const callback = sinon.stub();
+      const unlisten = _tweekRepo.listen(callback);
+
+      // Act
+      await _tweekRepo.useStore(new MemoryStore({ 'some/key/path': cachedItem('some value') }));
+      unlisten();
+
+      // Assert
+      sinon.assert.calledOnce(callback);
+      sinon.assert.calledWithExactly(callback, ['some/key/path', 'some/_', 'some/key/_']);
+    });
+
+    it('should notify on refreshed keys', async () => {
+      // Arrange
+      await initRepository();
+      const callback = sinon.stub();
+      const unlisten = _tweekRepo.listen(callback);
+
+      // Act
+      await refreshAndWait(['my_path/string_value', 'my_path/inner_path_1/_']);
+      unlisten();
+
+      // Assert
+      sinon.assert.calledOnce(callback);
+      sinon.assert.calledWithExactly(callback, [
+        'my_path/inner_path_1/int_value',
+        'my_path/inner_path_1/bool_positive_value',
+        'my_path/string_value',
+        'my_path/_',
+        'my_path/inner_path_1/_',
+      ]);
+    });
+
+    it('should notify only changed keys', async () => {
+      // Arrange
+      await initRepository();
+      const callback = sinon.stub();
+      await refreshAndWait(['my_path/string_value']);
+      const unlisten = _tweekRepo.listen(callback);
+
+      // Act
+      await refreshAndWait(['my_path/string_value', 'my_path/inner_path_1/_']);
+      unlisten();
+
+      // Assert
+      sinon.assert.calledOnce(callback);
+      sinon.assert.calledWithExactly(callback, [
+        'my_path/inner_path_1/int_value',
+        'my_path/inner_path_1/bool_positive_value',
+        'my_path/_',
+        'my_path/inner_path_1/_',
+      ]);
+    });
+
+    it('should stop notifying after unlisten', async () => {
+      // Arrange
+      await initRepository();
+      const callback = sinon.stub();
+      const unlisten = _tweekRepo.listen(callback);
+
+      // Act
+      await refreshAndWait(['my_path/string_value']);
+      unlisten();
+      await refreshAndWait(['my_path/string_value', 'my_path/inner_path_1/_']);
+
+      // Assert
+      sinon.assert.calledOnce(callback);
+      sinon.assert.calledWithExactly(callback, ['my_path/string_value', 'my_path/_']);
     });
   });
 });

--- a/js/tweek-local-cache/spec/unit/tweek-repository.spec.ts
+++ b/js/tweek-local-cache/spec/unit/tweek-repository.spec.ts
@@ -175,7 +175,7 @@ describe('tweek repo test', () => {
         let config = await _tweekRepo.get('_');
 
         // Assert
-        expect(config.innerPath1.firstValue).to.equal('value_1');
+        expect(config.somePath.innerPath1.firstValue).to.equal('value_1');
       });
 
       it('should get single key after scan prepare', async () => {
@@ -305,7 +305,8 @@ describe('tweek repo test', () => {
 
         // Assert
         expect(value)
-          .to.have.property('innerPath1')
+          .to.have.property('somePath')
+          .that.has.property('innerPath1')
           .that.deep.include({ firstValue: 'value_1' });
       });
 
@@ -819,7 +820,8 @@ describe('tweek repo test', () => {
 
       // Assert
       expect(config)
-        .to.have.property('innerPath1')
+        .to.have.property('somePath')
+        .that.has.property('innerPath1')
         .that.deep.include({ firstValue: 'value_1' });
     });
 
@@ -961,7 +963,8 @@ describe('tweek repo test', () => {
 
       // Assert
       expect(config)
-        .to.have.property('innerPath1')
+        .to.have.property('somePath')
+        .that.has.property('innerPath1')
         .that.deep.include({ firstValue: 'value_1' });
     });
 

--- a/js/tweek-local-cache/spec/unit/tweek-repository.spec.ts
+++ b/js/tweek-local-cache/spec/unit/tweek-repository.spec.ts
@@ -1066,7 +1066,10 @@ describe('tweek repo test', () => {
 
       // Assert
       sinon.assert.calledOnce(callback);
-      sinon.assert.calledWithExactly(callback, ['some/key/path', 'some/_', 'some/key/_']);
+      sinon.assert.calledWithExactly(
+        callback,
+        sinon.match.set.deepEquals(new Set(['some/key/path', 'some/_', 'some/key/_', '_'])),
+      );
     });
 
     it('should notify on useStore', async () => {
@@ -1081,7 +1084,10 @@ describe('tweek repo test', () => {
 
       // Assert
       sinon.assert.calledOnce(callback);
-      sinon.assert.calledWithExactly(callback, ['some/key/path', 'some/_', 'some/key/_']);
+      sinon.assert.calledWithExactly(
+        callback,
+        sinon.match.set.deepEquals(new Set(['some/key/path', 'some/_', 'some/key/_', '_'])),
+      );
     });
 
     it('should notify on refreshed keys', async () => {
@@ -1096,13 +1102,19 @@ describe('tweek repo test', () => {
 
       // Assert
       sinon.assert.calledOnce(callback);
-      sinon.assert.calledWithExactly(callback, [
-        'my_path/inner_path_1/int_value',
-        'my_path/inner_path_1/bool_positive_value',
-        'my_path/string_value',
-        'my_path/_',
-        'my_path/inner_path_1/_',
-      ]);
+      sinon.assert.calledWithExactly(
+        callback,
+        sinon.match.set.deepEquals(
+          new Set([
+            'my_path/inner_path_1/int_value',
+            'my_path/inner_path_1/bool_positive_value',
+            'my_path/string_value',
+            'my_path/_',
+            'my_path/inner_path_1/_',
+            '_',
+          ]),
+        ),
+      );
     });
 
     it('should notify only changed keys', async () => {
@@ -1118,12 +1130,18 @@ describe('tweek repo test', () => {
 
       // Assert
       sinon.assert.calledOnce(callback);
-      sinon.assert.calledWithExactly(callback, [
-        'my_path/inner_path_1/int_value',
-        'my_path/inner_path_1/bool_positive_value',
-        'my_path/_',
-        'my_path/inner_path_1/_',
-      ]);
+      sinon.assert.calledWithExactly(
+        callback,
+        sinon.match.set.deepEquals(
+          new Set([
+            'my_path/inner_path_1/int_value',
+            'my_path/inner_path_1/bool_positive_value',
+            'my_path/_',
+            'my_path/inner_path_1/_',
+            '_',
+          ]),
+        ),
+      );
     });
 
     it('should stop notifying after unlisten', async () => {
@@ -1139,7 +1157,10 @@ describe('tweek repo test', () => {
 
       // Assert
       sinon.assert.calledOnce(callback);
-      sinon.assert.calledWithExactly(callback, ['my_path/string_value', 'my_path/_']);
+      sinon.assert.calledWithExactly(
+        callback,
+        sinon.match.set.deepEquals(new Set(['my_path/string_value', 'my_path/_', '_'])),
+      );
     });
   });
 });

--- a/js/tweek-local-cache/src/index.ts
+++ b/js/tweek-local-cache/src/index.ts
@@ -6,4 +6,3 @@ import * as StoredKeyUtils from './stored-key-utils';
 export { StoredKeyUtils };
 export { default as MemoryStore } from './memory-store';
 export * from './tweek-repository';
-export * from './split-join';

--- a/js/tweek-local-cache/src/index.ts
+++ b/js/tweek-local-cache/src/index.ts
@@ -6,3 +6,4 @@ import * as StoredKeyUtils from './stored-key-utils';
 export { StoredKeyUtils };
 export { default as MemoryStore } from './memory-store';
 export * from './tweek-repository';
+export * from './split-join';

--- a/js/tweek-local-cache/src/split-join.ts
+++ b/js/tweek-local-cache/src/split-join.ts
@@ -3,23 +3,11 @@ export interface SplitJoin {
   join(fragments: string[]): string;
 }
 
-export class MemoizedTweekKeySplitJoin implements SplitJoin {
-  private readonly _cache = new Map<string, string[]>();
-
-  split(key: string): string[] {
-    const cached = this._cache.get(key);
-    if (cached) {
-      return cached;
-    }
-
-    const result = key.toLowerCase().split('/');
-    this._cache.set(key, result);
-    return result;
-  }
-
+export const TweekKeySplitJoin: SplitJoin = {
+  split(key: string) {
+    return key.toLowerCase().split('/');
+  },
   join(fragments: string[]) {
     return fragments.join('/');
-  }
-}
-
-export const TweekKeySplitJoin = new MemoizedTweekKeySplitJoin();
+  },
+};

--- a/js/tweek-local-cache/src/split-join.ts
+++ b/js/tweek-local-cache/src/split-join.ts
@@ -1,0 +1,25 @@
+export interface SplitJoin {
+  split(key: string): string[];
+  join(fragments: string[]): string;
+}
+
+export class MemoizedTweekKeySplitJoin implements SplitJoin {
+  private readonly _cache = new Map<string, string[]>();
+
+  split(key: string): string[] {
+    const cached = this._cache.get(key);
+    if (cached) {
+      return cached;
+    }
+
+    const result = key.toLowerCase().split('/');
+    this._cache.set(key, result);
+    return result;
+  }
+
+  join(fragments: string[]) {
+    return fragments.join('/');
+  }
+}
+
+export const TweekKeySplitJoin = new MemoizedTweekKeySplitJoin();

--- a/js/tweek-local-cache/src/trie.ts
+++ b/js/tweek-local-cache/src/trie.ts
@@ -1,8 +1,7 @@
+import { flatMap } from './utils';
+import { SplitJoin } from './split-join';
+
 export type TrieNode<TValue> = TValue | { [key: string]: TrieNode<TValue> };
-export type SplitJoin = {
-  split: (key: string) => string[];
-  join: (fragments: string[]) => string;
-};
 
 export default class Trie<TValue> {
   constructor(private readonly _splitJoin: SplitJoin) {}
@@ -63,5 +62,22 @@ export default class Trie<TValue> {
     return Object.keys(node)
       .map(name => this.list(this._splitJoin.join([...fragments, name]), index))
       .reduce((acc, next) => ({ ...acc, ...next }), initialValue);
+  }
+
+  listEntries(key?: string): string[] {
+    const fragments = (key && this._splitJoin.split(key)) || [];
+    const node = fragments.reduce((acc: any, next) => {
+      if (!acc) return null;
+      return acc[next];
+    }, this._root);
+
+    if (node === null || node === undefined) return [];
+
+    return flatMap(Object.keys(node), name => {
+      const subKey = this._splitJoin.join([...fragments, name]);
+      const subEntries = this.listEntries(subKey);
+      subEntries.push(subKey);
+      return subEntries;
+    });
   }
 }

--- a/js/tweek-local-cache/src/trie.ts
+++ b/js/tweek-local-cache/src/trie.ts
@@ -1,6 +1,6 @@
 import { SplitJoin } from './split-join';
 
-export type TrieNode = { [key: string]: TrieNode | undefined };
+export type TrieNode = { [key: string]: TrieNode };
 
 export type Walker<TValue> = (key: string, value: TValue) => void;
 
@@ -65,7 +65,7 @@ export default class Trie<TValue> {
     }
 
     for (const [name, subNode] of Object.entries(node)) {
-      this._walkNode(subNode!, [...fragments, name], walker);
+      this._walkNode(subNode, [...fragments, name], walker);
     }
   }
 

--- a/js/tweek-local-cache/src/trie.ts
+++ b/js/tweek-local-cache/src/trie.ts
@@ -2,6 +2,8 @@ import { SplitJoin } from './split-join';
 
 export type TrieNode = { [key: string]: TrieNode | undefined };
 
+export type Walker<TValue> = (key: string, value: TValue) => void;
+
 export default class Trie<TValue> {
   constructor(private readonly _splitJoin: SplitJoin) {}
 
@@ -36,44 +38,35 @@ export default class Trie<TValue> {
   }
 
   list(key?: string, index = 0): { [key: string]: TValue } {
-    const fragments = (key && this._splitJoin.split(key)) || [];
-    const node = this._getNode(fragments);
-    if (!node) {
-      return {};
-    }
-
-    const result = this._valueMap.has(node)
-      ? {
-          [this._splitJoin.join(fragments.slice(index))]: <TValue>this._valueMap.get(node),
-        }
-      : {};
-
-    for (const name of Object.keys(node)) {
-      const relative = this.list(this._splitJoin.join([...fragments, name]), index);
-      Object.assign(result, relative);
-    }
-
+    const result: { [key: string]: TValue } = {};
+    this.walk((key, value) => (result[key] = value), key, index);
     return result;
   }
 
   listEntries(key?: string, index = 0): string[] {
+    const result: string[] = [];
+    this.walk(key => result.push(key), key, index);
+    return result;
+  }
+
+  walk(walker: Walker<TValue>, key?: string, index = 0) {
     const fragments = (key && this._splitJoin.split(key)) || [];
     const node = this._getNode(fragments);
     if (!node) {
-      return [];
+      return;
     }
 
-    const result = [];
+    this._walkNode(node, fragments.slice(index), walker);
+  }
+
+  private _walkNode(node: TrieNode, fragments: string[], walker: Walker<TValue>) {
     if (this._valueMap.has(node)) {
-      result.push(this._splitJoin.join(fragments.slice(index)));
+      walker(this._splitJoin.join(fragments), this._valueMap.get(node)!);
     }
 
-    for (const name of Object.keys(node)) {
-      const subKey = this._splitJoin.join([...fragments, name]);
-      Array.prototype.push.apply(result, this.listEntries(subKey, index));
+    for (const [name, subNode] of Object.entries(node)) {
+      this._walkNode(subNode!, [...fragments, name], walker);
     }
-
-    return result;
   }
 
   private _getNode(fragments: string[]): TrieNode | undefined;

--- a/js/tweek-local-cache/src/tweek-repository.ts
+++ b/js/tweek-local-cache/src/tweek-repository.ts
@@ -5,8 +5,8 @@ import $$observable from 'symbol-observable';
 import Observable from 'zen-observable';
 import Trie from './trie';
 import {
-  createWarning,
   delay,
+  deprecated,
   distinct,
   flatMap,
   getAllPrefixes,
@@ -40,12 +40,6 @@ export type RepositoryListener = (updatedKeys: Set<string>) => void;
 export type Listen = (listen: RepositoryListener) => Unlisten;
 
 const allowedKeyStates = new Set([RepositoryKeyState.requested, RepositoryKeyState.cached, RepositoryKeyState.missing]);
-
-const createDeprecationWarning = (deprecated: keyof TweekRepository, replacement: keyof TweekRepository) =>
-  createWarning(`'TweekRepository.${deprecated}' is deprecated. use 'TweekRepository.${replacement}' instead`);
-const getDeprecatedWarning = createDeprecationWarning('get', 'getValue');
-const observeDeprecatedWarning = createDeprecationWarning('observe', 'observeValue');
-const refreshDeprecatedWarning = createDeprecationWarning('refresh', 'expire');
 
 export class TweekRepository {
   private _emitter = createChangeEmitter<Set<string>>();
@@ -148,9 +142,8 @@ export class TweekRepository {
   /**
    * @deprecated Please use `getValue`
    */
+  @deprecated('TweekRepository', 'getValue')
   public get<T = any>(key: string): Promise<Optional<T> | T> {
-    getDeprecatedWarning();
-
     const cached = this.getCached(key);
 
     if (!cached) {
@@ -201,8 +194,8 @@ export class TweekRepository {
   /**
    * @deprecated Please use `expire`
    */
+  @deprecated('TweekRepository', 'expire')
   public refresh(keysToRefresh?: string[]) {
-    refreshDeprecatedWarning();
     this.expire(keysToRefresh);
   }
 
@@ -228,9 +221,8 @@ export class TweekRepository {
   /**
    * @deprecated Please use `observeValue`
    */
+  @deprecated('TweekRepository', 'observeValue')
   public observe<T = any>(key: string): Observable<T> {
-    observeDeprecatedWarning();
-
     const isScan = isScanKey(key);
 
     return new Observable<any>(observer => {

--- a/js/tweek-local-cache/src/utils/index.ts
+++ b/js/tweek-local-cache/src/utils/index.ts
@@ -1,10 +1,9 @@
+import { MissingKey, RepositoryCachedKey, RepositoryKeyState } from '../types';
+import Optional from '../optional';
+
 export * from './arrayUtils';
 export * from './keyUtils';
 export * from './stringUtils';
-
-export function isNullOrUndefined(x: unknown): x is null | undefined {
-  return x === null || x === undefined;
-}
 
 export function delay(timeout: number): Promise<void> {
   return new Promise(resolve => setTimeout(resolve, timeout));
@@ -18,4 +17,19 @@ export function once(fn: Function): Function {
     p = undefined;
     return result;
   };
+}
+
+export function createWarning(message: string) {
+  return once(() => {
+    if (typeof process !== 'undefined' && process.env.NODE_ENV !== 'production') {
+      console.warn(message);
+    }
+  });
+}
+
+export function getValueOrOptional<T>(cached: RepositoryCachedKey<T> | MissingKey): T | Optional<T> {
+  if (cached.isScan) {
+    return cached.value;
+  }
+  return cached.state === RepositoryKeyState.missing ? Optional.none() : Optional.some(cached.value);
 }

--- a/js/tweek-local-cache/src/utils/keyUtils.ts
+++ b/js/tweek-local-cache/src/utils/keyUtils.ts
@@ -1,13 +1,13 @@
+import { TweekKeySplitJoin } from '../split-join';
+
 export const getAllPrefixes = (key: string) => {
-  return key
-    .split('/')
+  return TweekKeySplitJoin.split(key)
     .slice(0, -1)
     .reduce((acc: string[], next) => [...acc, [...acc.slice(-1), next].join('/')], []);
 };
 
 export const getKeyPrefix = (key: string) =>
-  key
-    .split('/')
+  TweekKeySplitJoin.split(key)
     .slice(0, -1)
     .join('/');
 

--- a/js/tweek-local-cache/tsconfig.json
+++ b/js/tweek-local-cache/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "extends": "../../tsconfig",
   "compilerOptions": {
+    "experimentalDecorators": true,
     /* Basic Options */
     "lib": ["dom", "esnext"],
     "outDir": "./dist"


### PR DESCRIPTION
**tweek-local-cache**
1. added `getValue` method that will replace `get`
2. added `observeValue` method that will replace `observe`
3. now emitting all changed keys, the `listen` method now gets a `Set` of all the keys that were affected by the addKeys/useStore/expire
4. changed implementation of `getValue` and `get` to use `listen` instead of `observe` because of suspected memory leak
5. added deprecation warnings for `get`, `observe`, and `refresh`
6. optimized `trie` a little (use for..of instead of forEach/map/reduce)

**react-tweek**
1. check if key was changed before triggering state update
2. improve initial state in `useTweekValue`