### PR TITLE
fixed a bug where a stale value is returned from tweek react

### DIFF
--- a/js/react-tweek/package.json
+++ b/js/react-tweek/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-tweek",
-  "version": "0.6.1",
+  "version": "0.7.0",
   "description": "react bindings for tweek",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/js/react-tweek/src/createUseTweekValue.test.tsx
+++ b/js/react-tweek/src/createUseTweekValue.test.tsx
@@ -148,6 +148,37 @@ describe('createUseTweekValue', () => {
     expect(unsubscribe).toHaveBeenCalledTimes(1);
   });
 
+  test('returns expected values when changing the repository', () => {
+    const firstCachedValue = 'Jake the Dog';
+    const secondCachedValue = 'Finn the Human';
+
+    let values: string[] = [];
+
+    const Component = () => {
+      const value = useTweekValue(keyPath, defaultValue);
+      values.push(value);
+      return <Empty value={value} />;
+    };
+
+    const render = (value: string) => {
+      const repository = new TweekRepository({ client: {} as any });
+      repository.addKeys({ [keyPath]: value });
+      return (
+        <TweekContext.Provider value={repository}>
+          <Component />
+        </TweekContext.Provider>
+      );
+    };
+
+    let testRenderer: ReactTestRenderer;
+    act(() => {
+      testRenderer = renderer.create(render(firstCachedValue));
+    });
+    act(() => testRenderer.update(render(secondCachedValue)));
+
+    expect(values).toEqual([firstCachedValue, secondCachedValue, secondCachedValue]);
+  });
+
   test('create prepared hook', () => {
     const value = 'some cached value';
     repository.addKeys({ [keyPath]: value });

--- a/js/react-tweek/src/createUseTweekValue.test.tsx
+++ b/js/react-tweek/src/createUseTweekValue.test.tsx
@@ -148,15 +148,15 @@ describe('createUseTweekValue', () => {
     expect(unsubscribe).toHaveBeenCalledTimes(1);
   });
 
-  test('returns expected values when changing the repository', () => {
+  test('value from the hook should equal the value from the repository when changing the repository', () => {
     const firstCachedValue = 'Jake the Dog';
     const secondCachedValue = 'Finn the Human';
 
-    let values: string[] = [];
+    let values: { valueFromHook: string; valueFromRepo: string }[] = [];
 
-    const Component = () => {
+    const Component = ({ repository }: { repository: TweekRepository }) => {
       const value = useTweekValue(keyPath, defaultValue);
-      values.push(value);
+      values.push({ valueFromHook: value, valueFromRepo: repository.getCached(keyPath)!.value });
       return <Empty value={value} />;
     };
 
@@ -165,7 +165,7 @@ describe('createUseTweekValue', () => {
       repository.addKeys({ [keyPath]: value });
       return (
         <TweekContext.Provider value={repository}>
-          <Component />
+          <Component repository={repository} />
         </TweekContext.Provider>
       );
     };
@@ -175,8 +175,7 @@ describe('createUseTweekValue', () => {
       testRenderer = renderer.create(render(firstCachedValue));
     });
     act(() => testRenderer.update(render(secondCachedValue)));
-
-    expect(values).toEqual([firstCachedValue, secondCachedValue, secondCachedValue]);
+    values.forEach(({ valueFromHook, valueFromRepo }) => expect(valueFromHook).toEqual(valueFromRepo));
   });
 
   test('create prepared hook', () => {

--- a/js/react-tweek/src/createUseTweekValue.ts
+++ b/js/react-tweek/src/createUseTweekValue.ts
@@ -66,7 +66,7 @@ export const createUseTweekValue = (
 
     if (!isEqual(args, storedArgs.current)) {
       storedArgs.current = args;
-      return getTweekValue();
+      return valueReducer(tweekValue, getTweekValue());
     }
 
     return tweekValue;

--- a/js/react-tweek/src/createUseTweekValue.ts
+++ b/js/react-tweek/src/createUseTweekValue.ts
@@ -48,25 +48,25 @@ export const createUseTweekValue = (
     const getTweekValue = () => getValueOrDefault(...args);
     const [tweekValue, setTweekValue] = React.useReducer<Reducer<T, T>, null>(valueReducer, null, getTweekValue);
 
-    React.useEffect(
-      () =>
+    React.useEffect(() => {
+      const newTweekValue = getTweekValue();
+      if (!isEqual(newTweekValue, tweekValue)) {
+        setTweekValue(newTweekValue);
+      }
+
+      return (
         tweekRepository &&
         tweekRepository.listen(updatedKeys => {
           if (updatedKeys.has(keyPath)) {
             setTweekValue(getTweekValue());
           }
-        }),
-      args,
-    );
+        })
+      );
+    }, args);
 
     if (!isEqual(args, storedArgs.current)) {
       storedArgs.current = args;
-
-      const newTweekValue = getTweekValue();
-      if (!isEqual(newTweekValue, tweekValue)) {
-        setTweekValue(newTweekValue);
-        return newTweekValue;
-      }
+      return getTweekValue();
     }
 
     return tweekValue;

--- a/js/react-tweek/src/createUseTweekValue.ts
+++ b/js/react-tweek/src/createUseTweekValue.ts
@@ -43,24 +43,24 @@ export const createUseTweekValue = (
     ensureHooks();
 
     const tweekRepository = React.useContext(TweekContext);
-    const dependencies: [OptionalTweekRepository, string, T] = [tweekRepository, keyPath, defaultValue];
-    const storedDependencies = React.useRef(dependencies);
-    const getTweekValue = () => getValueOrDefault(...dependencies);
+    const args: [OptionalTweekRepository, string, T] = [tweekRepository, keyPath, defaultValue];
+    const storedArgs = React.useRef(args);
+    const getTweekValue = () => getValueOrDefault(...args);
     const [tweekValue, setTweekValue] = React.useReducer<Reducer<T, T>, null>(valueReducer, null, getTweekValue);
 
-    React.useEffect(() => {
-      return (
+    React.useEffect(
+      () =>
         tweekRepository &&
         tweekRepository.listen(updatedKeys => {
           if (updatedKeys.has(keyPath)) {
             setTweekValue(getTweekValue());
           }
-        })
-      );
-    }, dependencies);
+        }),
+      args,
+    );
 
-    if (!isEqual(dependencies, storedDependencies.current)) {
-      storedDependencies.current = dependencies;
+    if (!isEqual(args, storedArgs.current)) {
+      storedArgs.current = args;
 
       const newTweekValue = getTweekValue();
       if (!isEqual(newTweekValue, tweekValue)) {


### PR DESCRIPTION
Fixed a bug where, in some occasions, a stale value is returned from `useTweekValue`.
This occurs when using `useTweekValue` in a component, and during its lifetime once of its dependencies (e.g. `TweekContext`) changes, the first render of the component will return the value calculated beforehand, with the old `TweekContext`

This happened due to the fact that the new value calculate, after a dependency has changed, is inside a `useEffect` hook, which runs after the component's render phase.