### PR TITLE
fix: typedefs for TweekManagementClient need fast-json-patch as a dependency, not devDependency

### DIFF
--- a/js/tweek-client/package.json
+++ b/js/tweek-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tweek-client",
-  "version": "2.0.3",
+  "version": "2.0.4",
   "description": "Tweek client for JavaScript",
   "author": "Soluto",
   "license": "MIT",
@@ -26,13 +26,15 @@
     "@types/zen-observable": "^0.8.0",
     "chai": "^4.1.2",
     "chai-as-promised": "^7.1.1",
-    "fast-json-patch": "^3.0.0-1",
     "fetch-mock": "^9.5.1",
     "mocha": "^7.0.0",
     "rimraf": "^3.0.0",
     "sinon": "^9.0.2",
     "ts-node": "^8.0.2",
     "typescript": "^3.3.1"
+  },
+  "optionalDependencies": {
+    "fast-json-patch": "^3.0.0-1"
   },
   "scripts": {
     "dev": "tsc -w",


### PR DESCRIPTION
fix: fast-json-patch must be installed for typedefs to resolve when consuming TweekManagementClient

Symptom that this resolves:

```ERROR in /Users/alex.petty/src/catalinalabs/wixi-web-ui/node_modules/tweek-client/dist/TweekManagementClient/types.d.ts(1,27):
TS2307: Cannot find module 'fast-json-patch'.
Version: typescript 3.8.2
Time: 18752 ms
```