### PR TITLE
Fixed dotnet tests

### DIFF
--- a/dotnet/Dockerfile
+++ b/dotnet/Dockerfile
@@ -1,4 +1,4 @@
-FROM microsoft/dotnet:1-sdk
+FROM mcr.microsoft.com/dotnet/sdk:6.0
 
 COPY . /test-environment
 

--- a/dotnet/Tweek.Client.Tests/ContextTestCasesProvider.cs
+++ b/dotnet/Tweek.Client.Tests/ContextTestCasesProvider.cs
@@ -106,7 +106,7 @@ namespace Tweek.Client.Tests
             };
         }
 
-        internal static IEnumerable<object[]> INCLUDE_TEST_CASES()
+        public static IEnumerable<object[]> INCLUDE_TEST_CASES()
         {
             yield return new object[] {
                 "@tweek_clients_tests/test_category/_",
@@ -121,7 +121,7 @@ namespace Tweek.Client.Tests
             };
         }
 
-        internal static IEnumerable<object[]> FLATTEN_TEST_CASES()
+        public static IEnumerable<object[]> FLATTEN_TEST_CASES()
         {
             yield return new object[] {
                 "@tweek_clients_tests/_",
@@ -133,7 +133,7 @@ namespace Tweek.Client.Tests
             };
         }
 
-        internal static IEnumerable<object[]> IGNORE_KEY_TYPES_TEST_CASES()
+        public static IEnumerable<object[]> IGNORE_KEY_TYPES_TEST_CASES()
         {
             yield return new object[] {
                 "@tweek_clients_tests/test_category/test_key2",

--- a/dotnet/Tweek.Client.Tests/Tweek.Client.Tests.csproj
+++ b/dotnet/Tweek.Client.Tests/Tweek.Client.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp1.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/dotnet/Tweek.Client.Tests/Tweek.Client.Tests.csproj
+++ b/dotnet/Tweek.Client.Tests/Tweek.Client.Tests.csproj
@@ -5,10 +5,10 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.0.0" />
-    <PackageReference Include="xunit" Version="2.2.0" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.2.0" />
-    <PackageReference Include="FakeItEasy" Version="3.4.2" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.0" />
+    <PackageReference Include="xunit" Version="2.4.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5" />
+    <PackageReference Include="FakeItEasy" Version="7.3.1" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
.NET tests failed because the docker image of the SDK used to run them is now deprecated and is not available on dockerhub.
To fix this issue it was necessary to use available docker images.
The changes made:

- Use .NET sdk version 6.0 docker image for tests
- Use .NET 6.0 in the tests project
- Updated nuget packages to the latest versions (otherwise the tests do not run)
- Changed some test case methods from internal to static because of [XUnit requirement](https://xunit.net/xunit.analyzers/rules/xUnit1016)